### PR TITLE
Alteração na exibição da data no histórico de pedidos

### DIFF
--- a/src/components/CardOrderHistory/CardOrderHistory.js
+++ b/src/components/CardOrderHistory/CardOrderHistory.js
@@ -3,13 +3,19 @@ import {CardDiv} from './styled';
 
 function CardOrderHistory(props) {
 
+  const timeStamp = props.order.createdAt
+  const milliseconds = timeStamp * 1000
+  const dateObject = new Date(milliseconds)
+
+  const dataLegivel = dateObject.toLocaleString("pt-BR", {day: 'numeric', month: 'long'})
+
 
   return (
         <CardDiv>
             <div>
                 <h4 id="titulo">{props.order.restaurantName}</h4>
-                <p>{props.order.createdAt}</p>
-                <h4 id="valor">SUBTOTAL: R${props.order.totalPrice}</h4>
+                <p>{dataLegivel}</p>
+                <h4 id="valor">SUBTOTAL: R$ {props.order.totalPrice}</h4>
             </div>        
         </CardDiv>
   );


### PR DESCRIPTION
Oi meninas,
Na parte de histórico de pedidos, cada pedido mostra a data em que foi feito. Antes mostrava a data em Timestamp, mas agora já converte para "dia + mês".